### PR TITLE
Update package.json to allow HTTPS clone request

### DIFF
--- a/client/quizzie/package.json
+++ b/client/quizzie/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "quizzie": "https://github.com/The-CodeINN/quizzie/client/quizzie.git",
     "@radix-ui/react-alert-dialog": "^1.0.5",
     "@radix-ui/react-avatar": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.5",


### PR DESCRIPTION
I can't "npm install" the package dependencies due to SSH permission issues so I added HTTPS request to package.json.